### PR TITLE
Fix file upload use binary mode for Python 3

### DIFF
--- a/h5pp/h5p/library/h5pdefaultstorage.py
+++ b/h5pp/h5p/library/h5pdefaultstorage.py
@@ -284,21 +284,21 @@ class H5PDefaultStorage:
             path = os.path.join(path, 'editor', files.getType() + 's')
             if not os.path.exists(path):
                 os.makedirs(path)
-            with open(os.path.join(path, files.getName()), 'w+') as f:
+            with open(os.path.join(path, files.getName()), 'wb+') as f:
                 f.write(filedata)
         elif filedata != None and contentid != '0':
             path = os.path.join(path, 'content', str(
                 contentid), files.getType() + 's')
             if not os.path.exists(path):
                 os.makedirs(path)
-            with open(os.path.join(path, files.getName()), 'w+') as f:
+            with open(os.path.join(path, files.getName()), 'wb+') as f:
                 f.write(filedata)
         elif contentid == '0':
             path = os.path.join(path, 'editor', files.getType() + 's')
             content = files.getFile()
             if not os.path.exists(path):
                 os.makedirs(path)
-            with open(os.path.join(path, files.getName()), 'w+') as f:
+            with open(os.path.join(path, files.getName()), 'wb+') as f:
                 for chunk in content.chunks():
                     f.write(chunk)
         else:
@@ -307,7 +307,7 @@ class H5PDefaultStorage:
             content = files.getFile()
             if not os.path.exists(path):
                 os.makedirs(path)
-            with open(os.path.join(path, files.getName()), 'w+') as f:
+            with open(os.path.join(path, files.getName()), 'wb+') as f:
                 for chunk in content.chunks():
                     f.write(chunk)
 


### PR DESCRIPTION
Python 3 requires wb flag for opening file when writing binary data. 